### PR TITLE
fix: replace achievements plugin with working alternatives

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   github-metrics:
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: production
     permissions:
       contents: write
@@ -18,16 +18,30 @@ jobs:
           repositories: 1000
           retries: 10
           repositories_affiliations: owner, collaborator
-          base: ""
-          config_order: github.achievements, github.reactions
+          base: header, activity, community, repositories
+          config_order: base.header, isocalendar, languages, habits, reactions
           template: classic
           config_timezone: Europe/Paris
-          
-          plugin_achievements: true
-          plugin_achievements_display: detailed
-          plugin_achievements_secrets: yes
-          plugin_achievements_threshold: B
-          
+
+          # Isometric commit calendar
+          plugin_isocalendar: true
+          plugin_isocalendar_duration: half-year
+
+          # Most used languages
+          plugin_languages: true
+          plugin_languages_sections: most-used
+          plugin_languages_colors: github
+          plugin_languages_limit: 8
+          plugin_languages_indepth: true
+
+          # Coding habits
+          plugin_habits: true
+          plugin_habits_from: 200
+          plugin_habits_days: 14
+          plugin_habits_charts: true
+          plugin_habits_trim: true
+
+          # Reactions
           plugin_reactions: true
           plugin_reactions_limit: 1000
           plugin_reactions_display: absolute


### PR DESCRIPTION
## Summary

This PR fixes the workflow error caused by the `achievements` plugin failing due to GitHub's deprecation of Projects Classic.

## Problem

The workflow was failing with the error:
```
Projects (classic) is being deprecated in favor of the new Projects experience
```

This is because the `lowlighter/metrics` achievements plugin queries the deprecated Projects Classic API, which GitHub has sunset (see [GitHub's announcement](https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/)).

## Investigation

I researched the `lowlighter/metrics` repository and found:
- The latest version is 3.34 (we're already using `@latest`)
- This is a known issue documented in their [discussions](https://github.com/lowlighter/metrics/discussions) and [issues](https://github.com/lowlighter/metrics/issues)
- There is no fix available yet in the upstream repository

## Solution

Since there's no upstream fix available, this PR removes the broken `achievements` plugin and replaces it with other interesting and working plugins:

1. **Isometric commit calendar** (`isocalendar`) - A beautiful 3D visualization of commit activity
2. **Most used languages** (`languages`) - Shows programming language distribution with indepth analysis
3. **Coding habits** (`habits`) - Displays coding activity patterns and charts

These plugins provide engaging profile metrics without relying on the deprecated Projects Classic API.

## Changes

- Removed `plugin_achievements` and related configuration
- Added `plugin_isocalendar` for commit calendar visualization
- Added `plugin_languages` with indepth analysis enabled
- Added `plugin_habits` with activity charts
- Updated `base` to include header, activity, community, and repositories
- Updated `config_order` to reflect the new plugin arrangement

Fixes #1

@h55nick can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25683ec920e24ac1a202f85f2b384587)